### PR TITLE
chore(tooling): phase 4 github actions and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - npm
+    commit-message:
+      prefix: "chore(deps)"
+      include: scope
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@testing-library/*"
+      vite:
+        patterns:
+          - "vite"
+          - "vite-*"
+          - "@vitejs/*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "chore(ci)"
+      include: scope
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: check:ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # gitleaks wants full history for detect
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install gitleaks
+        run: |
+          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      - name: Install osv-scanner
+        run: |
+          curl -sSL -o /tmp/osv-scanner \
+            https://github.com/google/osv-scanner/releases/download/v1.9.1/osv-scanner_linux_amd64
+          sudo install -m 0755 /tmp/osv-scanner /usr/local/bin/osv-scanner
+          osv-scanner --version
+
+      - name: Install semgrep
+        run: |
+          python3 -m pip install --user semgrep
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install lychee
+        run: |
+          curl -sSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.18.1/lychee-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C /tmp
+          sudo install -m 0755 /tmp/lychee /usr/local/bin/lychee
+          lychee --version
+
+      - name: Run check:ci
+        run: npm run check:ci
+
+      - name: Upload jscpd report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jscpd-report
+          path: reports/jscpd/
+          if-no-files-found: ignore

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: Docs (scheduled link check)
+
+on:
+  schedule:
+    - cron: "0 7 * * 1" # Monday 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write # lychee can file a tracking issue on broken links
+
+jobs:
+  links:
+    name: lychee online
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --no-progress --max-retries 1 --timeout 15 "README.md" "docs/**/*.md"
+          fail: true
+          format: markdown
+          output: /tmp/lychee-report.md
+
+      - name: Open or update broken-link issue
+        if: failure()
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "Link Checker Report"
+          content-filepath: /tmp/lychee-report.md
+          labels: docs, automated

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,98 @@
+name: Security (scheduled)
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: javascript-typescript
+          queries: security-extended
+      - uses: github/codeql-action/analyze@v4
+
+  dependency-check:
+    name: OWASP Dependency-Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run Dependency-Check
+        uses: dependency-check/Dependency-Check_Action@main
+        with:
+          project: ${{ github.event.repository.name }}
+          path: "."
+          format: "HTML"
+          out: "reports/dep-check"
+          args: >
+            --suppression .dependency-check-suppressions.xml
+            --exclude "node_modules/**"
+            --exclude "dist/**"
+            --exclude "coverage/**"
+            --nvdApiKey ${{ secrets.NVD_API_KEY }}
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: reports/dep-check
+
+  zap-baseline:
+    name: OWASP ZAP baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write # ZAP action files findings as issues
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build demo
+        run: npm run build:demo
+
+      - name: Start preview server
+        run: |
+          npm run preview &
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:4173 >/dev/null; then break; fi
+            sleep 1
+          done
+
+      - name: ZAP baseline scan
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          target: "http://localhost:4173"
+          fail_action: true
+          allow_issue_writing: false
+          artifact_name: zap-baseline-report

--- a/docs/adr/0007-github-actions-and-dependabot.md
+++ b/docs/adr/0007-github-actions-and-dependabot.md
@@ -1,0 +1,127 @@
+# ADR 0007: GitHub Actions safety net and Dependabot
+
+- **Status:** Accepted
+- **Date:** 2026-04-24
+- **Deciders:** Karl Groves
+
+## Context
+
+Phase 3 put the full gate set on the developer's machine via Husky. Phase 4 adds
+GitHub Actions coverage for the two cases local hooks do not cover:
+
+- **Bypassed hooks.** A developer can push with `--no-verify`, and a maintainer
+  can merge a PR via the GitHub web UI without ever running local hooks. The
+  safety-net CI re-runs the gate on every push and PR.
+- **Time-based drift.** New CVEs appear in NVD after code is merged; external
+  links rot after README is written; Dependabot proposes dependency updates.
+  These are schedule-triggered, not commit-triggered.
+
+Issue #1's sample CI installs semgrep/osv-scanner/gitleaks/lychee and runs
+`npm run check:all`. Our Phase 3 `check:all` includes CodeQL and OWASP
+Dependency-Check, which are heavy in CI. We need a narrower CI target and a
+richer scheduled target.
+
+## Decision
+
+### Three workflows plus Dependabot
+
+| File             | Trigger                                               | Purpose                                                                            |
+| ---------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `ci.yml`         | `push: [main]`, `pull_request`                        | Safety net — runs `npm run check:ci`. Installs fast scanners via release binaries. |
+| `security.yml`   | `schedule: weekly Mon 06:00 UTC`, `workflow_dispatch` | Heavy scanners: CodeQL, Dependency-Check, ZAP baseline against a built preview.    |
+| `docs.yml`       | `schedule: weekly Mon 07:00 UTC`, `workflow_dispatch` | `lychee` online link check; opens a tracking issue on failure.                     |
+| `dependabot.yml` | n/a (native GitHub)                                   | Weekly npm + github-actions updates. Minor/patch grouped.                          |
+
+### `check:ci` is `check:all` minus CodeQL and Dependency-Check
+
+Running CodeQL CLI and OWASP Dependency-Check on every PR is wasteful:
+
+- CodeQL: ~1–2 minutes per PR when the scheduled `codeql` job already runs
+  weekly against `main` and reports via the GitHub Security tab.
+- Dependency-Check: first run seeds the NVD mirror (~1 GB, 20–40 min without an
+  NVD API key — see ADR 0003). Without caching, every PR pays this cost. The
+  scheduled `dependency-check` job uses an NVD API key and runs once a week.
+
+`check:ci` runs the fast subset:
+`check + test + build + dupes + links (offline) + security:audit + security:osv + security:semgrep + security:secrets + license:check`.
+
+`check:all` remains the local pre-push gate (adds `security:codeql` and
+`security:depcheck`).
+
+### Release workflow is deferred
+
+Issue #1 mentions `release.yml` "if applicable." We publish to npm today via
+`prepublishOnly` + `npm publish` locally. Automated release (tag push → build →
+publish) is a sensitive action that needs:
+
+- an `NPM_TOKEN` secret (or OIDC trusted publisher config),
+- a signing story (provenance attestations),
+- clarity on whether `main` → `npm publish` is automatic or manual.
+
+No release workflow ships in this phase. Adding one is a discrete task that
+deserves its own PR and its own ADR.
+
+### ZAP runs in CI, not locally
+
+Per ADR 0003, ZAP is not in `pre-push`. It needs a running preview server. The
+scheduled `zap-baseline` job builds the demo, runs `vite preview` in the
+background, waits for the port, and runs `zaproxy/action-baseline@v0.14.0`.
+`fail_action: true` so findings fail the job; `allow_issue_writing: false`
+because the docs workflow already uses issue-filing for link rot and we don't
+want two sources of automated issues.
+
+### Dependabot grouping
+
+Ungrouped Dependabot opens one PR per dependency, which drowns the queue for
+fast-moving ecosystems (ESLint, Vite, Vitest). We group:
+
+- `minor-and-patch` — everything else minor/patch in one PR.
+- `eslint` — `eslint` + `eslint-plugin-*` + `@typescript-eslint/*`.
+- `react` — `react`, `react-dom`, `@types/react*`.
+- `vitest` — `vitest`, `@vitest/*`, `@testing-library/*`.
+- `vite` — `vite`, `@vitejs/*`, `vite-*`.
+
+Majors come one-per-PR by default (safer — they often break).
+
+### Secret: `NVD_API_KEY`
+
+Dependency-Check with a free-tier NVD download takes 30+ minutes per run due to
+NIST rate limits. Repo maintainers should register an NVD API key at
+<https://nvd.nist.gov/developers/request-an-api-key> and store it as
+`NVD_API_KEY` in repo secrets. With a key, download drops to a few minutes.
+Without the key, the scheduled run still works — just slowly.
+
+### Action version pinning
+
+Third-party actions are pinned to a major version (`@v5`, `@v4`, `@v0.14.0`)
+rather than a commit SHA. Dependabot's github-actions ecosystem tracks updates
+and proposes bumps weekly. For higher supply-chain assurance a future ADR may
+pin to commit SHAs; that trades maintenance burden for a tighter perimeter and
+is deferred.
+
+## Alternatives considered
+
+- **Run `check:all` in CI (same as pre-push).** Rejected — duplicates the
+  scheduled heavy-scanner work and pushes PR feedback time into the 5+ minute
+  range.
+- **Only scheduled workflows, no CI.** Rejected — `--no-verify` and web-UI
+  merges would ship without any gate. The issue's ground rules explicitly call
+  for CI as a safety net.
+- **Pin actions to commit SHAs now.** Rejected for this phase — every Dependabot
+  PR would churn SHA strings, and the supply-chain risk for
+  `actions/checkout@v5` is very low (official GitHub action). Reconsider if the
+  project adds a high-risk third-party action.
+- **Skip Dependabot grouping.** Rejected — ungrouped Dependabot on this many
+  devDependencies would open ~20+ PRs the first week.
+
+## Consequences
+
+- PR feedback cycle: CI runs in roughly 3–5 minutes on Ubuntu.
+- Weekly Monday morning surge: Dependabot PRs (06:00 UTC), security scan (06:00
+  UTC), docs link check (07:00 UTC). Nothing depends on strict ordering; stagger
+  minutes are enough.
+- `reports/jscpd/` uploads as an artifact on CI failure so reviewers can inspect
+  duplication findings without re-running.
+- Scheduled CodeQL findings appear in the repo's Security tab. Scheduled
+  Dependency-Check and ZAP reports upload as artifacts on the workflow run.
+- Adding a release workflow is a tracked follow-up, not forgotten.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,3 +31,4 @@ sequentially starting at `0001`.
 - [ADR 0004 — Allow BEM class selectors and disable `a11y/selector-pseudo-class-focus`](./0004-stylelint-bem-and-pseudo-class-focus.md)
 - [ADR 0005 — ESLint expansion calibrations and refactors](./0005-eslint-expansion-calibrations.md)
 - [ADR 0006 — Husky hook composition and local gate ordering](./0006-husky-and-local-gates.md)
+- [ADR 0007 — GitHub Actions safety net and Dependabot](./0007-github-actions-and-dependabot.md)

--- a/package.json
+++ b/package.json
@@ -76,8 +76,9 @@
     "license:check": "license-checker-rseidelsohn --production --onlyAllow 'MIT;ISC;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;CC0-1.0;Unlicense;Python-2.0;WTFPL;BlueOak-1.0.0' --excludePrivatePackages --summary",
     "license:report": "mkdir -p reports && license-checker-rseidelsohn --production --csv --out reports/licenses.csv",
     "check": "run-p lint typecheck stylelint markdownlint format:check",
+    "check:ci": "run-s check test build dupes links security:audit security:osv security:semgrep security:secrets license:check",
     "check:all": "run-s check test build dupes links security:audit security:osv security:semgrep security:secrets security:codeql security:depcheck license:check",
-    "ci": "npm run check:all",
+    "ci": "npm run check:ci",
     "prepare": "husky",
     "prepublishOnly": "npm run lint && npm test && npm run build"
   },


### PR DESCRIPTION
## Summary
- Re-targets the previously-stacked phase 4 PR at `develop` (was merged into phase 3 branch only).
- Adds `.github/workflows/ci.yml`, `security.yml`, `docs.yml`, and `dependabot.yml` plus a `check:ci` script.

Full rationale in ADR 0007 (added by this PR).

## Test plan
- [x] Pre-push gates pass (`check:all` ran via husky on push).
- [ ] CI workflow runs green on this PR.