### PR TITLE
chore(release): add release.yml for OIDC-based npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v1.2.3). Must already exist."
+        required: true
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write # required for npm provenance via OIDC
+
+jobs:
+  publish:
+    name: Build and publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify tag matches package.json version
+        env:
+          INPUT_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          tag_version="${INPUT_TAG#v}"
+          pkg_version=$(node -p "require('./package.json').version")
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag $INPUT_TAG does not match package.json version $pkg_version"
+            exit 1
+          fi
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run pre-publish gates
+        run: npm run check:ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public

--- a/docs/adr/0007-github-actions-and-dependabot.md
+++ b/docs/adr/0007-github-actions-and-dependabot.md
@@ -61,6 +61,8 @@ publish) is a sensitive action that needs:
 No release workflow ships in this phase. Adding one is a discrete task that
 deserves its own PR and its own ADR.
 
+**Resolved (2026-04-30):** see ADR 0010.
+
 ### ZAP runs in CI, not locally
 
 Per ADR 0003, ZAP is not in `pre-push`. It needs a running preview server. The

--- a/docs/adr/0010-release-workflow.md
+++ b/docs/adr/0010-release-workflow.md
@@ -1,0 +1,109 @@
+# ADR 0010: Automated npm release workflow
+
+- **Status:** Accepted
+- **Date:** 2026-04-30
+- **Deciders:** Karl Groves
+
+## Context
+
+ADR 0007 deferred the release workflow because it required up-front decisions on
+auth, provenance, and trigger model that did not belong inside the broader
+"GitHub Actions safety net" PR. Issue #11 tracked the follow-up. Today we
+publish via local `npm publish` after `prepublishOnly` runs lint, tests, and
+build. That works for a one-person maintainer cadence but has three problems:
+
+1. The artifact's provenance cannot be cryptographically attested — npm's
+   provenance feature requires the publish to happen from a known CI environment
+   over OIDC.
+2. A laptop-published release is whatever happened to be on disk at the time. A
+   CI release reproduces from the tagged commit only.
+3. Pre-publish gates can be skipped locally (`npm publish --ignore-scripts`,
+   environment differences). CI runs the same `check:ci` as every PR.
+
+## Decision
+
+### Auth: OIDC trusted publisher (no `NPM_TOKEN`)
+
+We use npm's [trusted publisher](https://docs.npmjs.com/trusted-publishers)
+configuration with GitHub Actions as the OIDC issuer. No long-lived `NPM_TOKEN`
+is stored in GitHub secrets. The npm package settings page lists this repo + the
+`Release` workflow + the `npm-publish` environment as the trusted publisher; npm
+exchanges the GitHub OIDC token for a short-lived publish token at job time.
+
+This requires `permissions: id-token: write` on the job, which the workflow sets
+explicitly. `contents: read` is the only other permission needed.
+
+### Provenance: enabled
+
+`npm publish --provenance --access public` attaches a sigstore-backed
+attestation tying the published tarball to the workflow run, the commit, and the
+source repo. Consumers can verify with `npm audit signatures`. Given the
+security-heavy stack already in this repo (CodeQL, OWASP scanners, gitleaks),
+shipping unattested artifacts would be inconsistent.
+
+### Trigger: tag push only (with `workflow_dispatch` escape hatch)
+
+The workflow fires on `push: tags: ['v*.*.*']` and on manual `workflow_dispatch`
+(for re-running a previously created tag). It does **not** fire on merge to
+`main`. Rationale:
+
+- Tag push is an explicit, human-authored release event. There is no scenario
+  where a merged PR should silently publish a new version.
+- `semantic-release`-style automation requires Conventional Commits to drive
+  version bumps. Commitlint already enforces Conventional Commits in this repo,
+  but version planning still benefits from a human in the loop for a pre-1.0
+  component library where minor/major boundaries are judgment calls.
+- The `bump-and-go` workflow already used by this maintainer ends with a
+  human-cut tag; the release workflow picks up from there.
+
+The workflow verifies the tag matches `package.json` version before publishing,
+so a stale tag or a mismatched bump fails fast.
+
+### Pre-publish gates: full `check:ci` plus build
+
+The job runs `npm run check:ci` (the same gate every PR runs) and then
+`npm run build` before `npm publish`. We do not rely on `prepublishOnly` to
+re-run gates — when CI is the publisher, gates run as explicit named steps so
+failures are visible per-step in the run summary.
+
+`size-limit` is included via `check:ci`, so a release that breaks the bundle
+budget fails the publish job.
+
+### Environment: `npm-publish`
+
+The job declares `environment: npm-publish`. This:
+
+- Lets us add required reviewers in the future without changing the workflow.
+- Surfaces the publish target separately in the GitHub deployments UI.
+- Scopes any future environment-specific secrets/variables to publish runs only.
+
+The environment exists with no protection rules today; protection can be added
+later without touching the workflow.
+
+## Alternatives considered
+
+- **`NPM_TOKEN` secret.** Simpler to set up but creates a long-lived publish
+  credential that has to be rotated and audited. OIDC eliminates the secret
+  entirely.
+- **`semantic-release`.** Powerful but assumes the project is past the pre-1.0
+  point where every minor bump needs human judgment. Reconsider after v1.0.0.
+- **Trigger on merge to `main`.** Conflates "code is mergeable" with "code is
+  releasable." A typo fix on `main` should not produce an npm release.
+- **Skip provenance.** Saves nothing — `--provenance` is a single flag once OIDC
+  is configured.
+
+## Operational notes
+
+- First publish requires configuring the trusted publisher on
+  `npmjs.com/package/@afixt/a11y-calc/access` after the first manual publish.
+  Until then, the workflow will fail with `ENEEDAUTH`.
+- To cut a release: `npm version patch|minor|major`, push the tag.
+- To re-run a publish for an existing tag: GitHub UI → Actions → Release → Run
+  workflow → enter `vX.Y.Z`.
+
+## Consequences
+
+- One more workflow file to maintain (`.github/workflows/release.yml`).
+- Releases are reproducible from CI and cryptographically attested.
+- Maintainer no longer needs npm credentials on local machines.
+- Issue #11 can be closed.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,3 +34,4 @@ sequentially starting at `0001`.
 - [ADR 0007 — GitHub Actions safety net and Dependabot](./0007-github-actions-and-dependabot.md)
 - [ADR 0008 — Performance budgets and web-vitals placement](./0008-performance-budgets.md)
 - [ADR 0009 — Accessibility layering and Phase 6 docs](./0009-a11y-layering-and-docs.md)
+- [ADR 0010 — Automated npm release workflow](./0010-release-workflow.md)


### PR DESCRIPTION
Closes #11.

## Summary
- Adds `.github/workflows/release.yml` that publishes to npm on `v*.*.*` tag push (with `workflow_dispatch` escape hatch).
- Uses npm OIDC trusted publisher (no `NPM_TOKEN`) and `--provenance` attestations.
- Verifies tag matches `package.json` version before publishing; runs full `check:ci` as pre-publish gate.
- Full rationale and operational notes in [ADR 0010](docs/adr/0010-release-workflow.md). Marks ADR 0007 deferral resolved.

## Test plan
- [ ] CI workflow passes on this PR.
- [ ] After merge: configure trusted publisher on npmjs.com for `@afixt/a11y-calc` (workflow `release.yml`, environment `npm-publish`).
- [ ] First release: `npm version patch && git push --follow-tags` and verify the Release workflow publishes.