### PR TITLE
docs(adr): record TypeDoc re-check

### DIFF
--- a/docs/adr/0009-a11y-layering-and-docs.md
+++ b/docs/adr/0009-a11y-layering-and-docs.md
@@ -95,6 +95,12 @@ For a single-component library with ~7 exported types and one component, the
 site would be almost empty. The TSDoc hover-docs cover the use case more
 directly. If the library surface grows, a future ADR can revisit.
 
+**Re-check 2026-04-30 (issue #13):** `src/index.ts` exports 6 public symbols
+(`Calculator` + 5 types: `AngleMode`, `CalculatorMode`, `CalculatorTheme`,
+`Operator`, `ScientificFunction`). Below the ~15-symbol threshold; deferral
+stands. Next re-check trigger: a new entry point, a public hook export, or
+crossing 15 symbols.
+
 ### `llms.txt` at the repo root
 
 Added per the [llmstxt.org](https://llmstxt.org) convention: a short


### PR DESCRIPTION
Closes #13.

## Summary
- Re-checked the public surface per issue #13's revisit criteria.
- `src/index.ts` exports **6 symbols** (1 component + 5 types) — below the ~15-symbol threshold.
- Added a re-check note to ADR 0009 with the next trigger conditions (new entry point, public hook export, or crossing 15 symbols).

## Test plan
- [x] Read ADR 0009 reads cleanly with the new note.
- [ ] CI passes.