### PR TITLE
chore(deps): bump @afixt/a11y-assert to 2.1.3, reinstate engine-strict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,2 @@
 save-exact=true
-# engine-strict intentionally off — @afixt/a11y-assert pins its engines field
-# to `lts/*`, which npm does not resolve as a semver range and engine-strict
-# would treat as a fatal mismatch. Our Node floor is enforced by `.nvmrc` +
-# the CI `setup-node` action. See ADR 0009.
-engine-strict=false
+engine-strict=true

--- a/docs/adr/0009-a11y-layering-and-docs.md
+++ b/docs/adr/0009-a11y-layering-and-docs.md
@@ -78,6 +78,10 @@ Follow-up: file an upstream issue on `@afixt/a11y-assert` to change `"lts/*"` to
 `">=18"` or similar. When fixed, we can reinstate `engine-strict=true` on a
 future version bump.
 
+**Resolved (2026-04-30, issue #10):** `@afixt/a11y-assert@2.1.3` now declares
+`engines.node: ">=22.0.0"` (a real semver range). Bumped the pin and reinstated
+`engine-strict=true` in `.npmrc`.
+
 ### TypeDoc is deferred
 
 Issue #1 mentions TypeDoc as an optional build target. Phase 2 already enforces

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@afixt/a11y-assert": "2.1.1",
+        "@afixt/a11y-assert": "2.1.3",
         "@commitlint/cli": "20.5.0",
         "@commitlint/config-conventional": "20.5.0",
         "@double-great/stylelint-a11y": "3.4.10",
@@ -79,9 +79,9 @@
       "dev": true
     },
     "node_modules/@afixt/a11y-assert": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@afixt/a11y-assert/-/a11y-assert-2.1.1.tgz",
-      "integrity": "sha512-g/dBTCY98xSrahvxi7/yBL/1R6elxvsc3yBKRDSJ3TgEsqa/BRDeQ3mQnK3p7fw3M165mCA7aNfKygmayhl1Bw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@afixt/a11y-assert/-/a11y-assert-2.1.3.tgz",
+      "integrity": "sha512-OAVgyRADzZ5CPMP7HObnEuZlShqmzqq4eSJDUnLGoCnt6vyt/qg5aiXpPOTx6hzEqZ5uB4xTVWRaassZl2L4hw==",
       "dev": true,
       "dependencies": {
         "@afixt/afixt-engine": "^1.5.0",
@@ -92,7 +92,7 @@
         "a11y-assert": "bin/a11y-assert"
       },
       "engines": {
-        "node": "lts/*"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "puppeteer": ">=22"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
-    "@afixt/a11y-assert": "2.1.1",
+    "@afixt/a11y-assert": "2.1.3",
     "@commitlint/cli": "20.5.0",
     "@commitlint/config-conventional": "20.5.0",
     "@double-great/stylelint-a11y": "3.4.10",

--- a/src/__tests__/a11y.test.tsx
+++ b/src/__tests__/a11y.test.tsx
@@ -33,12 +33,12 @@ const OPTIONS = { engineOptions: { type: 'automatic' as const } };
 describe('Calculator a11y-assert (component)', () => {
   it('basic mode passes accessibility assertions on first render', async () => {
     renderInPageShell(<Calculator />);
-    await jestAdapter(() => document.body, [], OPTIONS);
+    await jestAdapter(() => Promise.resolve(document.body), [], OPTIONS);
   });
 
   it('scientific mode passes accessibility assertions on first render', async () => {
     renderInPageShell(<Calculator initialMode="scientific" />);
-    await jestAdapter(() => document.body, [], OPTIONS);
+    await jestAdapter(() => Promise.resolve(document.body), [], OPTIONS);
   });
 
   it('still passes after a few interactions in scientific mode', async () => {
@@ -53,6 +53,6 @@ describe('Calculator a11y-assert (component)', () => {
       document.querySelector<HTMLButtonElement>('[aria-label="Close parenthesis"]')!,
     );
 
-    await jestAdapter(() => document.body, [], OPTIONS);
+    await jestAdapter(() => Promise.resolve(document.body), [], OPTIONS);
   });
 });


### PR DESCRIPTION
Closes #10.

## Summary
Upstream fix already shipped: `@afixt/a11y-assert@2.1.3` declares `engines.node: ">=22.0.0"` (a real semver range) instead of `"lts/*"`. The Phase 6 workaround that disabled `engine-strict` is no longer needed.

- Bump pin: `2.1.1` → `2.1.3`
- Reinstate `engine-strict=true` in `.npmrc`
- Update jestAdapter call sites for the new `() => Promise<Element>` signature in 2.1.3 (used `Promise.resolve(document.body)` to satisfy `@typescript-eslint/require-await`)
- Mark deferral in ADR 0009 resolved

## Test plan
- [x] `npm install` succeeds under `engine-strict=true` on Node 22.
- [x] `npm run lint` clean.
- [x] `npm run typecheck` clean.
- [x] All 323 unit tests pass.
- [ ] CI passes.