### PR TITLE
chore(ci): target dependabot PRs at develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -44,6 +45,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
## Summary
- Adds `target-branch: develop` to both `npm` and `github-actions` ecosystems in `.github/dependabot.yml` so dependabot opens PRs against `develop` instead of `main`, matching our `develop` -> `main` release flow.
- The 6 previously open dependabot PRs (#22-#27) targeting `main` were closed; dependabot will reopen against `develop` once this is merged.

## Test plan
- [ ] Merge to `main` so dependabot picks up the new config (config is read from default branch).
- [ ] Confirm next dependabot run opens PRs with base = `develop`.