### PR TITLE
chore(deps): bump fast-uri to 3.1.2 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8074,9 +8074,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- Bumps locked `fast-uri` from `3.1.0` to `3.1.2` to clear two CVSS 7.5 advisories surfaced by `osv-scanner`:
  - [GHSA-q3j6-qgpj-74h6](https://osv.dev/GHSA-q3j6-qgpj-74h6) — fixed in 3.1.1
  - [GHSA-v39h-62p7-jpjc](https://osv.dev/GHSA-v39h-62p7-jpjc) — fixed in 3.1.2
- Dev-only transitive via \`ajv\` from \`@afixt/a11y-assert\`, \`@commitlint/cli\`, \`stylelint\`, and \`vite-plugin-dts\`. Not shipped to consumers.
- Lockfile-only diff (3 lines). Same pattern as commit \`c204105\` (basic-ftp / ip-address).

## Why now

Pre-push gate (\`npm run security:osv\`) is currently failing on \`develop\` for these two findings, blocking unrelated work. Unblocks the CLAUDE.md ADR (refs #1) and any other PR that runs the local gate before push.

## Test plan

- [ ] CI green on this PR
- [ ] \`npm run security:osv\` passes locally on the merged branch
- [ ] No production dependency change (verify diff is lockfile-only)