### PR TITLE
chore(ci): authenticate npm for @afixt scope

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -25,8 +25,12 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          registry-url: "https://registry.npmjs.org"
+          scope: "@afixt"
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npx vitest run src/__tests__/a11y.test.tsx
 
   e2e:
@@ -40,8 +44,12 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          registry-url: "https://registry.npmjs.org"
+          scope: "@afixt"
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,13 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          registry-url: "https://registry.npmjs.org"
+          scope: "@afixt"
 
       - name: Install npm dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install trufflehog
         run: |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -24,8 +24,12 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          registry-url: "https://registry.npmjs.org"
+          scope: "@afixt"
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm run build
       - run: npm run size
 
@@ -40,8 +44,12 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          registry-url: "https://registry.npmjs.org"
+          scope: "@afixt"
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm run build:demo
 
       - name: Lighthouse CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
           registry-url: "https://registry.npmjs.org"
+          scope: "@afixt"
 
       - name: Verify tag matches package.json version
         env:
@@ -47,6 +48,8 @@ jobs:
 
       - name: Install npm dependencies
         run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Run pre-publish gates
         run: npm run check:ci

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,8 +37,12 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          registry-url: "https://registry.npmjs.org"
+          scope: "@afixt"
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Run Dependency-Check
         uses: dependency-check/Dependency-Check_Action@main
@@ -75,8 +79,12 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
+          registry-url: "https://registry.npmjs.org"
+          scope: "@afixt"
 
       - run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build demo
         run: npm run build:demo

--- a/package-lock.json
+++ b/package-lock.json
@@ -8074,9 +8074,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Wires GitHub Actions runners to authenticate against npm for the private `@afixt` scope. Every CI job has been failing on `npm ci` since `@afixt/a11y-assert@2.1.3` landed because its transitive `@afixt/test-utils` returns 404 from the public registry.

The org-level `NPM_TOKEN` secret is already configured, so this is the only change needed — once merged, the backlog of waiting PRs (#36, #37) goes green.

## What changes

- `actions/setup-node` gets `registry-url: "https://registry.npmjs.org"` and `scope: "@afixt"` in every workflow.
- Every `npm ci` step gets `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`.
- Touched: `ci.yml`, `a11y.yml` (×2 jobs), `performance.yml` (×2 jobs), `security.yml` (×2 jobs), `release.yml`.
- `docs.yml` (lychee link check) does not run `npm ci` — unchanged.
- `release.yml` publish step left untouched: it relies on the existing `id-token: write` + `environment: npm-publish` OIDC trusted-publisher path. `NODE_AUTH_TOKEN` is added only to the install step.

The IDE/editor warning "Context access might be invalid: NPM_TOKEN" is a false positive from local YAML linters that don't see org-level secrets. It does not affect runtime resolution.

## Stacking

Built on #36 (fast-uri 3.1.2 bump). Branch contains both commits, so merging #38 directly will land both. Either:

- Merge #36 first, then #38 auto-rebases to a clean workflow-only diff; or
- Merge #38 first; close #36 as superseded.

#37 (CLAUDE.md ADR) is rebased on #36 and will need a rebase onto develop after either of these lands.

## Test plan

- [ ] CI on this PR turns green after merge of #36 (or after this PR merges directly)
- [ ] CI on PR #36 turns green (rebase if needed)
- [ ] CI on PR #37 turns green (rebase if needed)
- [ ] Next `release.yml` workflow_dispatch installs deps successfully

Closes the CI-blocked-by-NPM_TOKEN gap.
