### PR TITLE
fix(ci): install scan tools before pre-publish gates in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0 # trufflehog scans full history in security:secrets
 
       - uses: actions/setup-node@v6
         with:
@@ -50,6 +51,31 @@ jobs:
         run: npm ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install trufflehog
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh \
+            | sudo sh -s -- -b /usr/local/bin
+          trufflehog --version
+
+      - name: Install osv-scanner
+        run: |
+          curl -sSL -o /tmp/osv-scanner \
+            https://github.com/google/osv-scanner/releases/download/v1.9.1/osv-scanner_linux_amd64
+          sudo install -m 0755 /tmp/osv-scanner /usr/local/bin/osv-scanner
+          osv-scanner --version
+
+      - name: Install semgrep
+        run: |
+          python3 -m pip install --user semgrep
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install lychee
+        run: |
+          curl -sSL https://github.com/lycheeverse/lychee/releases/download/lychee-v0.18.1/lychee-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz -C /tmp
+          sudo install -m 0755 /tmp/lychee /usr/local/bin/lychee
+          lychee --version
 
       - name: Run pre-publish gates
         run: npm run check:ci


### PR DESCRIPTION
Closes #40.

## Problem

Auto-publish to npm has been broken since v0.1.1. The release workflow runs `npm run check:ci`, whose `links` step calls `lychee`. The release runner had no `lychee` on PATH, so the step exited 127 and aborted `run-s` before the `Build`/`Publish` steps could run. npm `latest` is still stuck at `0.1.0` while v0.1.1 and v0.1.2 are tagged with GitHub releases but never published.

## Fix

The issue proposed installing lychee. That's necessary but not sufficient: `check:ci` runs `... links security:audit security:osv security:semgrep security:secrets ...`, and the release runner is **also** missing `osv-scanner`, `semgrep`, and `trufflehog`. They were never reached only because `links` failed first — installing just lychee would push the same 127 failure to the next step.

So this PR mirrors `ci.yml` fully:

- Install `trufflehog`, `osv-scanner`, `semgrep`, and `lychee` before `Run pre-publish gates`.
- Add `fetch-depth: 0` to the checkout so `trufflehog git file://.` can scan full history (matches `ci.yml`'s rationale).

## Acceptance

- [x] `release.yml` installs lychee before `npm run check:ci`
- [ ] Re-running the v0.1.2 release workflow (or a manual publish) results in `@afixt/a11y-calc@0.1.2` on npm — **post-merge backfill step, see below**
- [ ] Decide whether to backfill v0.1.1 to npm or skip it

## Backfill (after merge → tag rebuild)

Once this lands and a release tag is built from it, re-run the v0.1.2 release workflow (`workflow_dispatch` with `tag: v0.1.2`) to publish `0.1.2`. Recommend skipping v0.1.1 and letting v0.1.2 be the next published version, but that's a maintainer call.

> Note: the existing v0.1.2 tag predates this fix. Re-running the workflow on the old tag checks out the **tagged** `release.yml` (without these installs), so it would fail again. The backfill needs either a manual `npm publish` from a clean `v0.1.2` checkout, or a new tag built after this merges.