### PR TITLE
fix(ci): authenticate npm publish step in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,6 @@ jobs:
 
       - name: Install npm dependencies
         run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install trufflehog
         run: |
@@ -85,3 +83,5 @@ jobs:
 
       - name: Publish to npm with provenance
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Problem

After the #40 lychee fix, the v0.1.3 release run got all the way through the pre-publish gates and build, then failed at **Publish to npm with provenance**:

\`\`\`
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@afixt%2fa11y-calc - Not found
\`\`\`

A 404-on-PUT for an existing scoped package is npm's signature for an **unauthenticated/unauthorized** publish.

## Root cause

The publish step had no \`NODE_AUTH_TOKEN\` in its env. \`actions/setup-node\` writes an \`.npmrc\` containing \`_authToken=\${NODE_AUTH_TOKEN}\`, which is resolved from the environment **of the step that runs \`npm publish\`**. The token was instead set on the \`npm ci\` step (which doesn't need it).

## Fix

Move \`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` from the \`npm ci\` step to the \`npm publish\` step.

## Recovery after merge

Re-run the publish for the existing tag via \`workflow_dispatch\` from \`main\` (the dispatched run uses main's fixed workflow file but checks out the v0.1.3 tag for the package content):

\`\`\`
gh workflow run release.yml --ref main -f tag=v0.1.3
\`\`\`

No re-tag or version bump needed.

Follow-up to #40.

### Compare
https://github.com/AFixt/a11y-calc/compare/main...develop