### PR TITLE
feat(usecases): cover remaining scientific functions, error path, and keyboard

### DIFF
--- a/usecases/README.md
+++ b/usecases/README.md
@@ -76,6 +76,7 @@ Keyboard:
 
 - `keyboard-arithmetic.uc.yaml` — physical-keyboard digits/operators/Enter
 - `keyboard-clear-and-backspace.uc.yaml` — Backspace and Escape keys
+- `keyboard-scientific.uc.yaml` — `^`, `(` and `)` keys in scientific mode
 
 Mode and scientific functions:
 
@@ -91,6 +92,15 @@ Mode and scientific functions:
 - `scientific-inverse-trig.uc.yaml` — inverse trig in degrees (`asin(1) = 90`)
 - `scientific-angle-mode-toggle.uc.yaml` — radians/degrees toggle
 - `scientific-parentheses.uc.yaml` — grouping (`(2 + 3) x 4 = 20`)
+- `scientific-hyperbolic.uc.yaml` — hyperbolic cosine (`cosh(0) = 1`)
+- `scientific-inverse-hyperbolic.uc.yaml` — inverse hyperbolic cosine via 2nd
+  (`acosh(1) = 0`)
+- `scientific-logarithm-base10.uc.yaml` — log base 10 via 2nd (`log10(100) = 2`)
+- `scientific-cube.uc.yaml` — cube via 2nd (`2` becomes `8`)
+- `scientific-cube-root.uc.yaml` — cube root via 2nd (`27` becomes `3`)
+- `scientific-exponential.uc.yaml` — `eˣ` and `10ˣ` (`e⁰ = 1`, `10² = 100`)
+- `scientific-domain-error.uc.yaml` — error path; square root of a negative
+  number surfaces `Error`
 
 Accessibility-focused:
 

--- a/usecases/keyboard-scientific.uc.yaml
+++ b/usecases/keyboard-scientific.uc.yaml
@@ -1,0 +1,45 @@
+id: keyboard-scientific
+title: "Keyboard — power and parentheses keys in scientific mode"
+type: positive
+description: "The ^, ( and ) keys drive the scientific-mode keyboard model documented in
+  the README. With focus inside the widget, 2 ^ 3 Enter yields 8; after Escape,
+  ( 2 + 3 ) * 4 Enter yields 20. Companion to keyboard-arithmetic, which covers
+  the basic-mode keys."
+
+preconditions:
+  - "Calculator is loaded in basic mode showing 0"
+
+start_location: "http://localhost:4173"
+
+expected_result: "The display shows 8, then 20"
+
+steps:
+  - locate: button "Scientific"
+  - focus: button "Scientific"
+  - activate: button "Scientific"
+
+  # Place keyboard focus inside the calculator application region.
+  - locate: button "2"
+  - focus: button "2"
+
+  # 2 ^ 3 = 8 via the power key.
+  - keyboard: "2"
+  - keyboard: "^"
+  - keyboard: "3"
+  - keyboard: "Enter"
+  - verify: live_region "8"
+
+  - keyboard: "Escape"
+  - verify: live_region "0"
+
+  # ( 2 + 3 ) * 4 = 20 via the parenthesis keys.
+  - keyboard: "("
+  - keyboard: "2"
+  - keyboard: "+"
+  - keyboard: "3"
+  - keyboard: ")"
+  - verify: live_region "5"
+  - keyboard: "*"
+  - keyboard: "4"
+  - keyboard: "Enter"
+  - verify: live_region "20"

--- a/usecases/scientific-cube-root.uc.yaml
+++ b/usecases/scientific-cube-root.uc.yaml
@@ -1,0 +1,36 @@
+id: scientific-cube-root
+title: "Scientific mode — cube root via 2nd"
+type: positive
+description: "Switch to scientific mode, enter 27, enable the 2nd function set (which
+  swaps √x for ∛x), and press Cube root. The cube root of 27 is 3.
+  Complements scientific-square-root, which covers the primary √x function."
+
+preconditions:
+  - "Calculator is loaded in basic mode showing 0"
+
+start_location: "http://localhost:4173"
+
+expected_result: "The display shows 3"
+
+steps:
+  - locate: button "Scientific"
+  - focus: button "Scientific"
+  - activate: button "Scientific"
+
+  - locate: button "2"
+  - focus: button "2"
+  - activate: button "2"
+
+  - locate: button "7"
+  - focus: button "7"
+  - activate: button "7"
+  - verify: live_region "27"
+
+  - locate: button "Second function"
+  - focus: button "Second function"
+  - activate: button "Second function"
+
+  - locate: button "Cube root"
+  - focus: button "Cube root"
+  - activate: button "Cube root"
+  - verify: live_region "3"

--- a/usecases/scientific-cube.uc.yaml
+++ b/usecases/scientific-cube.uc.yaml
@@ -1,0 +1,31 @@
+id: scientific-cube
+title: "Scientific mode — cube a number (x³) via 2nd"
+type: positive
+description: "Switch to scientific mode, enter 2, enable the 2nd function set (which swaps
+  x² for x³), and press x cubed to get 8. Complements scientific-square, which
+  covers the primary x² function."
+
+preconditions:
+  - "Calculator is loaded in basic mode showing 0"
+
+start_location: "http://localhost:4173"
+
+expected_result: "The display shows 8"
+
+steps:
+  - locate: button "Scientific"
+  - focus: button "Scientific"
+  - activate: button "Scientific"
+
+  - locate: button "2"
+  - focus: button "2"
+  - activate: button "2"
+
+  - locate: button "Second function"
+  - focus: button "Second function"
+  - activate: button "Second function"
+
+  - locate: button "x cubed"
+  - focus: button "x cubed"
+  - activate: button "x cubed"
+  - verify: live_region "8"

--- a/usecases/scientific-domain-error.uc.yaml
+++ b/usecases/scientific-domain-error.uc.yaml
@@ -1,0 +1,33 @@
+id: scientific-domain-error
+title: "Scientific mode — square root of a negative number (error state)"
+type: negative
+description: "Switch to scientific mode, enter 4, negate it, and press Square root.
+  The square root of a negative number is a domain error: the calculator must
+  surface Error in the display rather than NaN or a number. Companion to
+  divide-by-zero, which covers the basic-mode error path."
+
+preconditions:
+  - "Calculator is loaded in basic mode showing 0"
+
+start_location: "http://localhost:4173"
+
+expected_result: "The display shows Error"
+
+steps:
+  - locate: button "Scientific"
+  - focus: button "Scientific"
+  - activate: button "Scientific"
+
+  - locate: button "4"
+  - focus: button "4"
+  - activate: button "4"
+
+  - locate: button "Toggle positive negative"
+  - focus: button "Toggle positive negative"
+  - activate: button "Toggle positive negative"
+  - verify: live_region "-4"
+
+  - locate: button "Square root"
+  - focus: button "Square root"
+  - activate: button "Square root"
+  - verify: live_region "Error"

--- a/usecases/scientific-exponential.uc.yaml
+++ b/usecases/scientific-exponential.uc.yaml
@@ -1,0 +1,42 @@
+id: scientific-exponential
+title: "Scientific mode — eˣ and 10ˣ exponential functions"
+type: positive
+description: "The exponential button exposes eˣ as its primary function and 10ˣ under 2nd.
+  e⁰ is 1; after clearing, 10² is 100. Covers both functions of the shared
+  button, including the 2nd-function swap."
+
+preconditions:
+  - "Calculator is loaded in basic mode showing 0"
+
+start_location: "http://localhost:4173"
+
+expected_result: "The display shows 1 for e⁰, then 100 for 10²"
+
+steps:
+  - locate: button "Scientific"
+  - focus: button "Scientific"
+  - activate: button "Scientific"
+
+  # e to the power of 0 is 1.
+  - locate: button "e to the power of x"
+  - focus: button "e to the power of x"
+  - activate: button "e to the power of x"
+  - verify: live_region "1"
+
+  - locate: button "All clear"
+  - focus: button "All clear"
+  - activate: button "All clear"
+
+  # 10 to the power of 2 is 100.
+  - locate: button "2"
+  - focus: button "2"
+  - activate: button "2"
+
+  - locate: button "Second function"
+  - focus: button "Second function"
+  - activate: button "Second function"
+
+  - locate: button "10 to the power of x"
+  - focus: button "10 to the power of x"
+  - activate: button "10 to the power of x"
+  - verify: live_region "100"

--- a/usecases/scientific-hyperbolic.uc.yaml
+++ b/usecases/scientific-hyperbolic.uc.yaml
@@ -1,0 +1,25 @@
+id: scientific-hyperbolic
+title: "Scientific mode — hyperbolic cosine"
+type: positive
+description: 'Switch to scientific mode and apply cosh to the initial 0. cosh(0) is 1.
+  The hyperbolic buttons are addressable by accessible name — "Hyperbolic
+  cosine" is unique among the rendered buttons (the inverse set is only
+  rendered while 2nd is active) — unlike the forward trig names, which
+  collide under substring matching (see scientific-inverse-trig).'
+
+preconditions:
+  - "Calculator is loaded in basic mode showing 0"
+
+start_location: "http://localhost:4173"
+
+expected_result: "The display shows 1"
+
+steps:
+  - locate: button "Scientific"
+  - focus: button "Scientific"
+  - activate: button "Scientific"
+
+  - locate: button "Hyperbolic cosine"
+  - focus: button "Hyperbolic cosine"
+  - activate: button "Hyperbolic cosine"
+  - verify: live_region "1"

--- a/usecases/scientific-inverse-hyperbolic.uc.yaml
+++ b/usecases/scientific-inverse-hyperbolic.uc.yaml
@@ -1,0 +1,31 @@
+id: scientific-inverse-hyperbolic
+title: "Scientific mode — inverse hyperbolic cosine via 2nd"
+type: positive
+description: "Switch to scientific mode, enter 1, enable the 2nd function set, and press
+  Inverse hyperbolic cosine. acosh(1) is 0. Exercises the inverse hyperbolic
+  set, which is only rendered while 2nd is active."
+
+preconditions:
+  - "Calculator is loaded in basic mode showing 0"
+
+start_location: "http://localhost:4173"
+
+expected_result: "The display shows 0"
+
+steps:
+  - locate: button "Scientific"
+  - focus: button "Scientific"
+  - activate: button "Scientific"
+
+  - locate: button "1"
+  - focus: button "1"
+  - activate: button "1"
+
+  - locate: button "Second function"
+  - focus: button "Second function"
+  - activate: button "Second function"
+
+  - locate: button "Inverse hyperbolic cosine"
+  - focus: button "Inverse hyperbolic cosine"
+  - activate: button "Inverse hyperbolic cosine"
+  - verify: live_region "0"

--- a/usecases/scientific-logarithm-base10.uc.yaml
+++ b/usecases/scientific-logarithm-base10.uc.yaml
@@ -1,0 +1,37 @@
+id: scientific-logarithm-base10
+title: "Scientific mode — log base 10 via 2nd"
+type: positive
+description: "Switch to scientific mode, enter 100, enable the 2nd function set (which
+  swaps ln for log base 10), and press Log base 10. log10(100) is 2.
+  Complements scientific-logarithm, which covers the primary ln function."
+
+preconditions:
+  - "Calculator is loaded in basic mode showing 0"
+
+start_location: "http://localhost:4173"
+
+expected_result: "The display shows 2"
+
+steps:
+  - locate: button "Scientific"
+  - focus: button "Scientific"
+  - activate: button "Scientific"
+
+  - locate: button "1"
+  - focus: button "1"
+  - activate: button "1"
+
+  - locate: button "0"
+  - focus: button "0"
+  - activate: button "0"
+  - activate: button "0"
+  - verify: live_region "100"
+
+  - locate: button "Second function"
+  - focus: button "Second function"
+  - activate: button "Second function"
+
+  - locate: button "Log base 10"
+  - focus: button "Log base 10"
+  - activate: button "Log base 10"
+  - verify: live_region "2"


### PR DESCRIPTION
## Summary

Audit of `usecases/` against the implemented feature surface (issue #79) found nine implemented features with no use case. This adds one `.uc.yaml` per gap, following the existing locate → focus → act house conventions, and updates the Coverage list in `usecases/README.md`.

## New use cases

| File | Flow |
| --- | --- |
| `scientific-hyperbolic.uc.yaml` | cosh(0) = 1 |
| `scientific-inverse-hyperbolic.uc.yaml` | acosh(1) = 0 via 2nd |
| `scientific-logarithm-base10.uc.yaml` | log10(100) = 2 via 2nd |
| `scientific-cube.uc.yaml` | 2³ = 8 via 2nd |
| `scientific-cube-root.uc.yaml` | ∛27 = 3 via 2nd |
| `scientific-exponential.uc.yaml` | e⁰ = 1, then 10² = 100 via 2nd |
| `scientific-domain-error.uc.yaml` | √−4 surfaces Error (negative path) |
| `keyboard-scientific.uc.yaml` | `^`, `(`, `)` physical keys in scientific mode |

Forward trig by accessible name stays deliberately uncovered — "Sine"/"Cosine"/"Tangent" collide under the runner's substring name matching, as documented in `scientific-inverse-trig.uc.yaml`.

## Verification

All 35 use cases validate with `usecase-runner validate`, and the eight new ones **pass when executed** against the built demo. Full local CI reproduction in the PR comment (GitHub Actions currently cannot start jobs — Actions budget exhausted, tracked in AFixt/vscode#252).

Fixes #79