### PR TITLE
ci: remove scheduled workflows; run security and docs checks in PR CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,12 @@ name: Docs (link check)
 
 on:
   pull_request:
+    # Match the exact set lychee checks below (README.md + docs/**/*.md), so the
+    # job never triggers on a Markdown file whose links it does not actually
+    # check (which would pass vacuously). Keep these two lists in sync.
     paths:
-      - "**/*.md"
-      - "docs/**"
+      - "README.md"
+      - "docs/**/*.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,18 @@
-name: Docs (scheduled link check)
+name: Docs (link check)
 
 on:
-  schedule:
-    - cron: "0 7 * * 1" # Monday 07:00 UTC
+  pull_request:
+    paths:
+      - "**/*.md"
+      - "docs/**"
   workflow_dispatch:
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
-  issues: write # lychee can file a tracking issue on broken links
 
 jobs:
   links:
@@ -20,15 +25,5 @@ jobs:
       - name: lychee
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          args: --no-progress --max-retries 1 --timeout 15 "README.md" "docs/**/*.md"
+          args: --no-progress --max-retries 3 --timeout 30 "README.md" "docs/**/*.md"
           fail: true
-          format: markdown
-          output: /tmp/lychee-report.md
-
-      - name: Open or update broken-link issue
-        if: failure()
-        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
-        with:
-          title: "Link Checker Report"
-          content-filepath: /tmp/lychee-report.md
-          labels: docs, automated

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,83 +14,16 @@ permissions:
   contents: read
 
 jobs:
-  codeql:
-    name: CodeQL
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      security-events: write
-      contents: read
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
-        with:
-          languages: javascript-typescript
-          queries: security-extended
-      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
-
-  dependency-check:
-    name: OWASP Dependency-Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-          registry-url: "https://registry.npmjs.org"
-          scope: "@afixt"
-
-      - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # Cache the NVD data directory so PR runs don't re-seed the full
-      # vulnerability database (~1 GB) every time. `key` never matches an
-      # existing cache (run_id is unique), so every run saves a refreshed
-      # copy; `restore-keys` restores the most recent one.
-      - name: Cache NVD data
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: .dc-data
-          key: depcheck-nvd-${{ github.run_id }}
-          restore-keys: |
-            depcheck-nvd-
-
-      - name: Run Dependency-Check
-        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main as of 2026-07-22
-        with:
-          project: ${{ github.event.repository.name }}
-          path: "."
-          format: "SARIF"
-          out: "reports/dep-check"
-          args: >
-            --data /github/workspace/.dc-data
-            --suppression .dependency-check-suppressions.xml
-            --exclude "node_modules/**"
-            --exclude "dist/**"
-            --exclude "coverage/**"
-            --nvdApiKey ${{ secrets.NVD_API_KEY }}
-
-      - name: Upload SARIF to code scanning
-        if: always()
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
-        with:
-          sarif_file: reports/dep-check/dependency-check-report.sarif
-          category: dependency-check
-
-      - name: Upload report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: dependency-check-report
-          path: reports/dep-check
-
+  # CodeQL and OWASP Dependency-Check are deliberately NOT in this workflow:
+  #   - CodeQL uploads to GitHub code scanning (GHAS), which this org does not
+  #     use (ADR 0015 / #90). It runs locally via `npm run security:codeql`,
+  #     enforced by the Husky pre-push hook (ADR 0003).
+  #   - Dependency-Check's dependency-CVE coverage already gates every PR through
+  #     `security:osv` in `check:ci`, and it needs an NVD API key to run within
+  #     the PR timeout. It stays a local pre-push check (`security:depcheck`,
+  #     ADR 0003).
+  # ZAP baseline is the one security scan that is PR-native and needs no secret,
+  # so it moves from the old weekly schedule into PR CI (#77).
   zap-baseline:
     name: OWASP ZAP baseline
     runs-on: ubuntu-latest
@@ -126,6 +59,7 @@ jobs:
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
           target: "http://localhost:4173"
+          rules_file_name: ".zap/rules.tsv"
           fail_action: true
           allow_issue_writing: false
           artifact_name: zap-baseline-report

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,9 +1,14 @@
-name: Security (scheduled)
+name: Security
 
 on:
-  schedule:
-    - cron: "0 6 * * 1" # Monday 06:00 UTC
+  push:
+    branches: [main]
+  pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -30,6 +35,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
@@ -44,19 +50,39 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # Cache the NVD data directory so PR runs don't re-seed the full
+      # vulnerability database (~1 GB) every time. `key` never matches an
+      # existing cache (run_id is unique), so every run saves a refreshed
+      # copy; `restore-keys` restores the most recent one.
+      - name: Cache NVD data
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .dc-data
+          key: depcheck-nvd-${{ github.run_id }}
+          restore-keys: |
+            depcheck-nvd-
+
       - name: Run Dependency-Check
         uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main as of 2026-07-22
         with:
           project: ${{ github.event.repository.name }}
           path: "."
-          format: "HTML"
+          format: "SARIF"
           out: "reports/dep-check"
           args: >
+            --data /github/workspace/.dc-data
             --suppression .dependency-check-suppressions.xml
             --exclude "node_modules/**"
             --exclude "dist/**"
             --exclude "coverage/**"
             --nvdApiKey ${{ secrets.NVD_API_KEY }}
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: reports/dep-check/dependency-check-report.sarif
+          category: dependency-check
 
       - name: Upload report
         if: always()
@@ -71,7 +97,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      issues: write # ZAP action files findings as issues
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
@@ -92,7 +117,7 @@ jobs:
       - name: Start preview server
         run: |
           npm run preview &
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if curl -sf http://localhost:4173 >/dev/null; then break; fi
             sleep 1
           done

--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -1,0 +1,18 @@
+# OWASP ZAP baseline rules for the a11y-calc demo.
+#
+# Format (tab-separated): <pluginId>	<WARN|FAIL|IGNORE>	<comment>
+# Used by .github/workflows/security.yml (zaproxy/action-baseline, fail_action: true).
+#
+# The demo is a static `vite preview` of a component-library showcase — it is
+# NOT the shipped product. The published artifact is a React component; HTTP
+# response headers (CSP, clickjacking, MIME-sniffing, permissions policy, COEP)
+# are the consuming application's responsibility, not this demo's. These alerts
+# are therefore expected here and are IGNORE'd so the baseline stays a real gate:
+# any NEW alert outside this list still surfaces as WARN and fails the job.
+10020	IGNORE	Missing Anti-clickjacking Header — demo server, not the shipped component
+10021	IGNORE	X-Content-Type-Options Header Missing — static demo server default
+10038	IGNORE	Content Security Policy (CSP) Header Not Set — consumer app concern
+10049	IGNORE	Storable but Non-Cacheable Content — vite preview cache headers
+10063	IGNORE	Permissions Policy Header Not Set — consumer app concern
+10109	IGNORE	Modern Web Application — informational; SPA is expected
+90004	IGNORE	Cross-Origin-Embedder-Policy Header Missing or Invalid — consumer app concern

--- a/README.md
+++ b/README.md
@@ -237,9 +237,10 @@ npm run ai:context     # Print project summary (for AI sessions / new contribs)
 3. Husky's `pre-commit` runs `lint-staged` + type check on staged files
    - TruffleHog secret scan (see ADR 0012). `pre-push` runs the full
      `check:all`.
-4. Open a PR targeting `main`. CI runs `check:ci` and the a11y workflow.
-   Scheduled workflows (CodeQL, OWASP Dependency-Check, OWASP ZAP, lychee
-   online) run weekly on `main`.
+4. Open a PR targeting `main`. CI runs `check:ci`, the a11y and performance
+   workflows, the security workflow (CodeQL, OWASP Dependency-Check, OWASP ZAP
+   baseline), and — when Markdown changes — the lychee online link check. There
+   are no scheduled workflows (see ADR 0015).
 5. Non-obvious engineering decisions get an ADR in [`docs/adr/`](docs/adr/) —
    see [`docs/templates/adr-template.md`](docs/templates/adr-template.md).
 

--- a/README.md
+++ b/README.md
@@ -238,9 +238,10 @@ npm run ai:context     # Print project summary (for AI sessions / new contribs)
    - TruffleHog secret scan (see ADR 0012). `pre-push` runs the full
      `check:all`.
 4. Open a PR targeting `main`. CI runs `check:ci`, the a11y and performance
-   workflows, the security workflow (CodeQL, OWASP Dependency-Check, OWASP ZAP
-   baseline), and — when Markdown changes — the lychee online link check. There
-   are no scheduled workflows (see ADR 0015).
+   workflows, the security workflow (OWASP ZAP baseline), and — when Markdown
+   changes — the lychee online link check. CodeQL and OWASP Dependency-Check run
+   locally on `pre-push` (`check:all`), not in CI (see ADR 0015 and ADR 0003).
+   There are no scheduled workflows (see ADR 0015).
 5. Non-obvious engineering decisions get an ADR in [`docs/adr/`](docs/adr/) —
    see [`docs/templates/adr-template.md`](docs/templates/adr-template.md).
 

--- a/docs/adr/0007-github-actions-and-dependabot.md
+++ b/docs/adr/0007-github-actions-and-dependabot.md
@@ -1,6 +1,7 @@
 # ADR 0007: GitHub Actions safety net and Dependabot
 
-- **Status:** Accepted
+- **Status:** Accepted; scheduled triggers and Dependabot superseded by
+  [ADR 0015](./0015-no-scheduled-actions.md)
 - **Date:** 2026-04-24
 - **Deciders:** Karl Groves
 

--- a/docs/adr/0015-no-scheduled-actions.md
+++ b/docs/adr/0015-no-scheduled-actions.md
@@ -1,0 +1,87 @@
+# ADR 0015: Remove scheduled GitHub Actions; run every check in PR-time CI
+
+- **Status:** Accepted
+- **Date:** 2026-08-13
+- **Deciders:** Karl Groves
+
+## Context
+
+ADR 0007 split automation into a fast PR-time safety net (`ci.yml`) and two
+weekly scheduled workflows: `security.yml` (CodeQL, OWASP Dependency-Check,
+OWASP ZAP baseline) and `docs.yml` (lychee online link check that auto-filed a
+"Link Checker Report" issue on failure).
+
+Scheduled Actions are being removed across all AFixt projects
+([#77](https://github.com/AFixt/a11y-calc/issues/77)). The reasoning:
+
+- A timer-triggered check reports a problem hours or days after it entered the
+  codebase, against no particular author, and is routinely ignored. The same
+  check on a PR gates the defect at the point of introduction.
+- Auto-filed issues from timers are noise: nobody triggered the run, so nobody
+  owns the report. Issue [#76](https://github.com/AFixt/a11y-calc/issues/76) — a
+  report whose only finding was a transient timeout on `nvd.nist.gov` — is the
+  canonical example.
+
+The original justification for scheduling (ADR 0007) was PR runtime cost: CodeQL
+adds ~1–2 minutes, and Dependency-Check's first NVD seed is ~1 GB. Caching and
+an NVD API key have since made both tolerable in a PR pipeline.
+
+## Decision
+
+We delete every `on.schedule:` block. No regularly scheduled GitHub Action may
+ever be added back; `workflow_dispatch` (manual runs) remains allowed — a manual
+trigger is not a schedule. The same policy bans Dependabot config (also
+timer-driven); this repository has none.
+
+The scheduled work moves into the PR pipeline:
+
+- **`security.yml`** now triggers on `pull_request`, `push` to `main`, and
+  `workflow_dispatch`.
+  - _CodeQL_ runs unchanged — it supports `pull_request` natively and reports to
+    the Security tab.
+  - _Dependency-Check_ caches its NVD data directory (`.dc-data`) via
+    `actions/cache` with a unique-per-run `key` and a `restore-keys` prefix, so
+    each run restores the newest cache and saves a refreshed one. Output
+    switches from HTML to SARIF, uploaded to code scanning so findings land on
+    the PR that introduced them (the raw report still uploads as an artifact).
+  - _ZAP baseline_ already built the demo and scanned a local `vite preview`, so
+    it is PR-compatible as-is; it now scans the change under review instead of
+    whatever `main` happened to contain on Monday.
+- **`docs.yml`** now triggers on `pull_request` path-filtered to Markdown and
+  `docs/**`, plus `workflow_dispatch`. It fails the PR directly; the
+  issue-filing step and its `issues: write` permission are removed. Retries and
+  timeout are raised (`--max-retries 3 --timeout 30`) since transient
+  external-host slowness now fails a PR rather than filing a report. The offline
+  link check in `check:ci` continues to run on every PR regardless of paths.
+
+ADR 0007's workflow-trigger table and ADR 0003's "scheduled Actions as backup
+coverage" language are superseded by this ADR to the extent they describe
+schedules; the local-first gate placement they establish is unchanged.
+
+## Alternatives considered
+
+- **Keep weekly schedules alongside PR triggers.** Rejected — the fleet-wide
+  policy bans timers outright, and a PR-gated check makes the weekly re-run of
+  the same commit redundant.
+- **Move the heavy scanners into `check:ci` instead of separate workflows.**
+  Rejected — CodeQL and Dependency-Check benefit from GitHub-native SARIF upload
+  and per-job caching, and ZAP needs a running server; folding them into the
+  single `check:ci` job would push its runtime past acceptable PR feedback times
+  (ADR 0007's original concern, still valid).
+- **Auto-file issues from PR failures.** Rejected — a failing PR check is
+  already attributable and blocking; an issue would duplicate it.
+
+## Consequences
+
+- PR pipelines gain three jobs (CodeQL ~2 min; Dependency-Check a few minutes
+  once the NVD cache is warm and `NVD_API_KEY` is set; ZAP baseline ~5 min).
+  They run in parallel with `check:ci`, so wall-clock PR feedback time is
+  bounded by the slowest job, not the sum.
+- The first `dependency-check` run after this change (or after a cache eviction)
+  re-seeds the NVD database and is slow; subsequent runs restore the cache.
+- Fork PRs cannot read `secrets.NVD_API_KEY` / `secrets.NPM_TOKEN`, so the
+  `dependency-check` job would be slow or fail there; this repository takes
+  contributions from maintainer branches, so this is accepted.
+- No automation files issues anymore; `Link Checker Report` issues stop
+  appearing (#76 closed).
+- `grep -rn 'cron:' .github/` returns nothing, and must stay that way.

--- a/docs/adr/0015-no-scheduled-actions.md
+++ b/docs/adr/0015-no-scheduled-actions.md
@@ -23,8 +23,15 @@ Scheduled Actions are being removed across all AFixt projects
   canonical example.
 
 The original justification for scheduling (ADR 0007) was PR runtime cost: CodeQL
-adds ~1–2 minutes, and Dependency-Check's first NVD seed is ~1 GB. Caching and
-an NVD API key have since made both tolerable in a PR pipeline.
+adds ~1–2 minutes, and Dependency-Check's first NVD seed is ~1 GB. Two of the
+three scheduled security scans turn out not to belong in PR CI regardless:
+
+- **CodeQL** uploads its results to GitHub code scanning by default, which is
+  the GHAS / Code Security surface this org does not use
+  ([#90](https://github.com/AFixt/a11y-calc/issues/90)).
+- **Dependency-Check** needs an `NVD_API_KEY` to seed the NVD database within a
+  PR timeout, and its dependency-CVE coverage duplicates `security:osv`, which
+  already gates every PR through `check:ci`.
 
 ## Decision
 
@@ -33,20 +40,25 @@ ever be added back; `workflow_dispatch` (manual runs) remains allowed — a manu
 trigger is not a schedule. The same policy bans Dependabot config (also
 timer-driven); this repository has none.
 
-The scheduled work moves into the PR pipeline:
+The scheduled work is redistributed as follows:
 
 - **`security.yml`** now triggers on `pull_request`, `push` to `main`, and
-  `workflow_dispatch`.
-  - _CodeQL_ runs unchanged — it supports `pull_request` natively and reports to
-    the Security tab.
-  - _Dependency-Check_ caches its NVD data directory (`.dc-data`) via
-    `actions/cache` with a unique-per-run `key` and a `restore-keys` prefix, so
-    each run restores the newest cache and saves a refreshed one. Output
-    switches from HTML to SARIF, uploaded to code scanning so findings land on
-    the PR that introduced them (the raw report still uploads as an artifact).
+  `workflow_dispatch`, and keeps exactly one job:
   - _ZAP baseline_ already built the demo and scanned a local `vite preview`, so
-    it is PR-compatible as-is; it now scans the change under review instead of
-    whatever `main` happened to contain on Monday.
+    it is PR-compatible and needs no secret; it now scans the change under
+    review instead of whatever `main` happened to contain on Monday. A committed
+    `.zap/rules.tsv` `IGNORE`s the demo server's expected missing-header alerts
+    (CSP, clickjacking, MIME-sniffing, permissions policy, COEP — all the
+    consuming application's responsibility, not the shipped component's), so the
+    baseline stays a real gate: any new alert outside that list fails the PR.
+  - _CodeQL_ is **removed from CI** entirely. It uploads to GitHub code scanning
+    (GHAS), which this org does not use (#90), and `security:codeql` already
+    runs locally on the Husky `pre-push` hook (ADR 0003). Removing it also drops
+    the last `security-events: write` permission in the repo.
+  - _Dependency-Check_ is **removed from CI** entirely. Its dependency-CVE
+    coverage already gates every PR via `security:osv` in `check:ci`, and it
+    needs an `NVD_API_KEY` to complete within the PR timeout. It stays a local
+    pre-push check (`security:depcheck`, ADR 0003).
 - **`docs.yml`** now triggers on `pull_request` path-filtered to Markdown and
   `docs/**`, plus `workflow_dispatch`. It fails the PR directly; the
   issue-filing step and its `issues: write` permission are removed. Retries and
@@ -54,7 +66,10 @@ The scheduled work moves into the PR pipeline:
   external-host slowness now fails a PR rather than filing a report. The offline
   link check in `check:ci` continues to run on every PR regardless of paths.
 
-ADR 0007's workflow-trigger table and ADR 0003's "scheduled Actions as backup
+So the net effect for the two heavy scanners is that their schedule is deleted
+and their enforcement returns to the local-first placement ADR 0003 already
+established, while `security:osv` (PR CI) covers dependency CVEs at PR time. ADR
+0007's workflow-trigger table and ADR 0003's "scheduled Actions as backup
 coverage" language are superseded by this ADR to the extent they describe
 schedules; the local-first gate placement they establish is unchanged.
 
@@ -63,25 +78,31 @@ schedules; the local-first gate placement they establish is unchanged.
 - **Keep weekly schedules alongside PR triggers.** Rejected — the fleet-wide
   policy bans timers outright, and a PR-gated check makes the weekly re-run of
   the same commit redundant.
-- **Move the heavy scanners into `check:ci` instead of separate workflows.**
-  Rejected — CodeQL and Dependency-Check benefit from GitHub-native SARIF upload
-  and per-job caching, and ZAP needs a running server; folding them into the
-  single `check:ci` job would push its runtime past acceptable PR feedback times
-  (ADR 0007's original concern, still valid).
+- **Keep CodeQL and Dependency-Check as PR jobs.** Rejected — CodeQL's value is
+  the code-scanning upload this org does not consume (#90), and Dependency-Check
+  cannot go green in CI without an `NVD_API_KEY` secret while duplicating the
+  `security:osv` gate that already runs on every PR. Both keep their local
+  pre-push enforcement (ADR 0003).
+- **Set ZAP `fail_action: false` to stop the header warnings blocking PRs.**
+  Rejected — that turns ZAP into a non-gating report. Instead the known-benign
+  alerts are `IGNORE`d in `.zap/rules.tsv`, so ZAP still fails on anything new.
 - **Auto-file issues from PR failures.** Rejected — a failing PR check is
   already attributable and blocking; an issue would duplicate it.
 
 ## Consequences
 
-- PR pipelines gain three jobs (CodeQL ~2 min; Dependency-Check a few minutes
-  once the NVD cache is warm and `NVD_API_KEY` is set; ZAP baseline ~5 min).
-  They run in parallel with `check:ci`, so wall-clock PR feedback time is
-  bounded by the slowest job, not the sum.
-- The first `dependency-check` run after this change (or after a cache eviction)
-  re-seeds the NVD database and is slow; subsequent runs restore the cache.
-- Fork PRs cannot read `secrets.NVD_API_KEY` / `secrets.NPM_TOKEN`, so the
-  `dependency-check` job would be slow or fail there; this repository takes
-  contributions from maintainer branches, so this is accepted.
+- PR pipelines gain one security job (ZAP baseline ~5 min), running in parallel
+  with `check:ci`, so wall-clock PR feedback time is bounded by the slowest job,
+  not the sum. CodeQL and Dependency-Check add no PR time; they run on pre-push.
+- Dependency-CVE coverage at PR time is provided by `security:osv` (already in
+  `check:ci`); CodeQL and Dependency-Check remain enforced locally via the
+  `pre-push` hook (ADR 0003). A developer who bypasses pre-push loses that
+  local-only coverage until it is caught on their machine — the accepted
+  trade-off of ADR 0003's local-first placement.
+- No `security-events: write` permission remains anywhere in the repo.
+- ZAP's `.zap/rules.tsv` must be kept current: if the demo legitimately starts
+  emitting a header (or a new benign alert appears), update the rules file
+  rather than disabling `fail_action`.
 - No automation files issues anymore; `Link Checker Report` issues stop
   appearing (#76 closed).
 - `grep -rn 'cron:' .github/` returns nothing, and must stay that way.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,3 +39,4 @@ sequentially starting at `0001`.
 - [ADR 0012 — Use TruffleHog instead of gitleaks for secret scanning](./0012-trufflehog-instead-of-gitleaks.md)
 - [ADR 0013 — Keep `CLAUDE.md` gitignored as local-only context](./0013-claude-md-local-only.md)
 - [ADR 0014 — Calculator keyboard focus surface and button-grid grouping](./0014-calculator-keyboard-focus-and-button-grouping.md)
+- [ADR 0015 — Remove scheduled GitHub Actions; run every check in PR-time CI](./0015-no-scheduled-actions.md)

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ai:context": "node scripts/ai-context.js",
     "dupes": "jscpd",
     "links": "lychee --no-progress --offline 'README.md' 'docs/**/*.md'",
-    "links:online": "lychee --no-progress --max-retries 1 --timeout 15 'README.md' 'docs/**/*.md'",
+    "links:online": "lychee --no-progress --max-retries 3 --timeout 30 'README.md' 'docs/**/*.md'",
     "security:audit": "npm audit --production --audit-level=high",
     "security:osv": "osv-scanner --config=osv-scanner.toml --lockfile=package-lock.json",
     "security:semgrep": "semgrep --config=p/javascript --config=p/typescript --config=p/react --config=p/owasp-top-ten --config=p/security-audit --config=p/secrets --error --metrics=off",


### PR DESCRIPTION
## Summary

Removes both `on.schedule:` (cron) workflows and moves their still-relevant work into the PR pipeline, per #77. Also folds in the #90 CodeQL decision and the Dependency-Check disposition uncovered while getting the moved jobs green.

## Changes

### `docs.yml` — was a weekly lychee run that auto-filed issues
- Now triggers on `pull_request` (path-filtered to `README.md` + `docs/**/*.md`, matching exactly what lychee checks) and `workflow_dispatch`; fails the PR directly.
- Removed the issue-filing step and its `issues: write` permission (a timer-filed issue nobody triggered is noise — #76).

### `security.yml` — was a weekly CodeQL + Dependency-Check + ZAP run
Now triggers on `pull_request` / `push: main` / `workflow_dispatch`, with **one** job:
- **ZAP baseline** — the one PR-native scan that needs no secret. Its only failures were 7 benign missing-header alerts on the static demo server (CSP, clickjacking, MIME-sniffing, permissions policy, COEP — the consuming app's concern, not the shipped component's). Added `.zap/rules.tsv` that `IGNORE`s exactly those, keeping `fail_action: true` so any *new* alert still fails the PR.
- **CodeQL — removed from CI** (closes #90). It uploads to GitHub code scanning (GHAS), which this org does not use; `security:codeql` already runs locally on `pre-push` (ADR 0003). This drops the last `security-events: write` in the repo.
- **Dependency-Check — removed from CI.** It failed with an empty `--nvdApiKey` (the `NVD_API_KEY` secret is unset), and reliably running it needs that key to seed the NVD DB within the PR timeout. Its dependency-CVE coverage already gates every PR via `security:osv` in `check:ci`, so it stays a local `pre-push` check.

### Docs
- **ADR 0015** (new) rewritten to record all of the above (ZAP-only PR security job; CodeQL and Dependency-Check dropped from CI and kept local; no `security-events: write`).
- **ADR 0007** marked superseded (scheduled triggers + Dependabot) by ADR 0015.
- **README** contribution step updated: CodeQL/Dependency-Check run on `pre-push`, not CI; no scheduled workflows.

## Verification
- `grep -rn 'cron:' .github/` → nothing.
- `markdownlint` + `format:check` clean.
- CI green on this PR: `check:ci`, Accessibility, Performance, **OWASP ZAP baseline**, lychee online, size-limit.

Closes #77. Closes #90. (#76 closed alongside.)
