### PR TITLE
fix(api): export CalculatorProps from the package root (#91)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { Calculator } from './components/Calculator/Calculator';
+export type { CalculatorProps } from './components/Calculator/Calculator';
 export type {
   AngleMode,
   CalculatorMode,
@@ -6,3 +7,7 @@ export type {
   Operator,
   ScientificFunction,
 } from './types/calculator';
+
+// `CalculatorState` and `ParenFrame` are intentionally NOT re-exported: they
+// are internal `useCalculator` reducer detail, not part of the public API.
+// See the note on those types in `./types/calculator`.

--- a/src/types/calculator.ts
+++ b/src/types/calculator.ts
@@ -49,6 +49,9 @@ export type CalculatorMode = 'basic' | 'scientific';
 /**
  * Snapshot of the arithmetic context captured when a parenthesis opens.
  * Restored when the matching parenthesis closes.
+ *
+ * @internal Reducer detail of `useCalculator`; not part of the public API and
+ * deliberately not re-exported from the package root (`src/index.ts`).
  */
 export interface ParenFrame {
   previousValue: string | null;
@@ -61,6 +64,9 @@ export interface ParenFrame {
  * Full calculator state. Every user interaction produces a new snapshot
  * by returning a replacement object from the reducer — the shape never
  * changes in place.
+ *
+ * @internal Reducer detail of `useCalculator`; not part of the public API and
+ * deliberately not re-exported from the package root (`src/index.ts`).
  */
 export interface CalculatorState {
   displayValue: string;


### PR DESCRIPTION
## Summary

`CalculatorProps` was declared in `Calculator.tsx` but never re-exported from `src/index.ts`, so it never reached the published type surface. Consumers writing the most common integration — a typed wrapper — hit `has no exported member 'CalculatorProps'`.

## Changes

- `src/index.ts`: `export type { CalculatorProps }` from the Calculator module. Additive, non-breaking, no runtime change.
- `src/types/calculator.ts`: mark `CalculatorState` and `ParenFrame` as `@internal` (they are `useCalculator` reducer detail), and add a comment in `src/index.ts` recording that they are deliberately **not** part of the public API — so the boundary is decided rather than incidental (per the issue's second question).

## Verification

- `npm run build` → `dist/src/index.d.ts` now includes `export type { CalculatorProps } ...`.
- `npm run lint` clean, `npm test` 323/323 pass.

Closes #91