### PR TITLE
test(e2e): run calculator.spec.ts in CI + guard reused preview server (#87)

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -56,8 +56,13 @@ jobs:
 
       - run: npm run build:demo
 
-      - name: Run a11y E2E
-        run: npx playwright test e2e/a11y.spec.ts --project=chromium
+      # Runs the full E2E suite — a11y.spec.ts (a11y-assert) AND calculator.spec.ts
+      # (arithmetic, keyboard, aria-pressed, announcements, scientific mode, focus
+      # order). calculator.spec.ts is the bulk of the suite and previously ran only
+      # locally, so it could drift out of sync with the app silently (#87, #80).
+      # Playwright attributes any failure to its spec file in the log and report.
+      - name: Run E2E suite (a11y + behavioural)
+        run: npx playwright test --project=chromium
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -21,7 +21,7 @@ const EXPECTED_TITLE = 'Accessible Calculator';
  * issue #87.
  */
 async function globalSetup(config: FullConfig): Promise<void> {
-  const baseURL = config.projects[0].use.baseURL ?? 'http://localhost:4173';
+  const baseURL = config.projects[0]?.use.baseURL ?? 'http://localhost:4173';
 
   let html: string;
   try {

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,51 @@
+import type { FullConfig } from '@playwright/test';
+
+/**
+ * The demo shell's `<title>`. Used as an identity marker so the suite can tell
+ * whether the server on the preview port is actually ours.
+ */
+const EXPECTED_TITLE = 'Accessible Calculator';
+
+/**
+ * Guard against `reuseExistingServer` running the whole suite against an
+ * unrelated app.
+ *
+ * With `reuseExistingServer: !process.env.CI`, if anything already holds the
+ * preview port locally, Playwright reuses it instead of starting the demo — so
+ * the suite silently runs against whatever that process serves. A wrong app
+ * produces a wall of confusing timeouts and wrong-content failures; a *similar*
+ * app could even produce false passes. Neither is obvious without an `lsof`.
+ *
+ * This preflight fetches the base URL once and fails fast, with a message that
+ * names the actual cause, if the served page is not the a11y-calc demo. See
+ * issue #87.
+ */
+async function globalSetup(config: FullConfig): Promise<void> {
+  const baseURL = config.projects[0].use.baseURL ?? 'http://localhost:4173';
+
+  let html: string;
+  try {
+    const response = await fetch(baseURL);
+    html = await response.text();
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `E2E preflight: could not reach the preview server at ${baseURL} (${cause}). ` +
+        `Start it with \`npm run preview\`, or let Playwright's webServer start it.`,
+    );
+  }
+
+  if (!html.includes(`<title>${EXPECTED_TITLE}</title>`)) {
+    throw new Error(
+      `E2E preflight: the server at ${baseURL} is not the a11y-calc demo ` +
+        `(expected \`<title>${EXPECTED_TITLE}</title>\` in the served HTML). ` +
+        `Something else is holding the preview port and \`reuseExistingServer\` picked it up. ` +
+        `Find it with \`lsof -i :4173\` and stop it, then re-run the E2E suite.`,
+    );
+  }
+}
+
+// Playwright resolves `globalSetup` to the module's default export, so this file
+// must default-export despite the repo-wide preference for named exports.
+// eslint-disable-next-line import-x/no-default-export -- required by Playwright's globalSetup contract
+export default globalSetup;

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -3,6 +3,10 @@ import type { FullConfig } from '@playwright/test';
 /**
  * The demo shell's `<title>`. Used as an identity marker so the suite can tell
  * whether the server on the preview port is actually ours.
+ *
+ * Kept in sync with the `<title>` in `index.html` (there is a comment there
+ * pointing back here). If the demo title changes, update both — otherwise this
+ * guard reports "not the a11y-calc demo" against the real demo.
  */
 const EXPECTED_TITLE = 'Accessible Calculator';
 
@@ -19,14 +23,27 @@ const EXPECTED_TITLE = 'Accessible Calculator';
  * This preflight fetches the base URL once and fails fast, with a message that
  * names the actual cause, if the served page is not the a11y-calc demo. See
  * issue #87.
+ *
+ * Ordering assumption: this relies on Playwright starting the configured
+ * `webServer` *before* running globalSetup, so the fetch hits a live server.
+ * That holds in the pinned Playwright version; if a future upgrade reverses it,
+ * the fetch below fails on every run and the "could not reach" message makes
+ * the cause obvious.
  */
 async function globalSetup(config: FullConfig): Promise<void> {
-  const baseURL = config.projects[0]?.use.baseURL ?? 'http://localhost:4173';
+  // Read the base URL from the resolved config rather than re-hardcoding the
+  // port (it lives in playwright.config.ts). Fail loudly if it is somehow
+  // absent instead of papering over it with a literal that could drift.
+  const baseURL = config.projects[0]?.use.baseURL;
+  if (!baseURL) {
+    throw new Error(
+      'E2E preflight: no base URL is configured — expected `use.baseURL` in playwright.config.ts.',
+    );
+  }
 
-  let html: string;
+  let response: Awaited<ReturnType<typeof fetch>>;
   try {
-    const response = await fetch(baseURL);
-    html = await response.text();
+    response = await fetch(baseURL);
   } catch (error) {
     const cause = error instanceof Error ? error.message : String(error);
     throw new Error(
@@ -35,6 +52,14 @@ async function globalSetup(config: FullConfig): Promise<void> {
     );
   }
 
+  if (!response.ok) {
+    throw new Error(
+      `E2E preflight: the server at ${baseURL} responded ${response.status} ${response.statusText}. ` +
+        `Expected the a11y-calc demo — check that the preview server built and served correctly.`,
+    );
+  }
+
+  const html = await response.text();
   if (!html.includes(`<title>${EXPECTED_TITLE}</title>`)) {
     throw new Error(
       `E2E preflight: the server at ${baseURL} is not the a11y-calc demo ` +

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- The E2E preflight guard uses this exact title as an identity marker.
+         If you change it, update EXPECTED_TITLE in e2e/global-setup.ts too. -->
     <title>Accessible Calculator</title>
   </head>
   <body>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
+  // Verifies the preview server is actually the a11y-calc demo before any test
+  // runs, so a stray process on the reused port can't be tested by mistake (#87).
+  globalSetup: './e2e/global-setup.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
## Summary

Closes the two gaps in #87 that let `e2e/calculator.spec.ts` (83 of 86 tests) drift out of sync with the app undetected — #80 was a live instance.

### 1. calculator.spec.ts now runs in CI
`a11y.yml`'s E2E job ran only `a11y.spec.ts`. It now runs the **full suite** (`npx playwright test --project=chromium`), so arithmetic, keyboard, `aria-pressed`, announcements, scientific mode, and focus order are enforced on every PR. Playwright attributes any failure to its spec file in the log and HTML report.

### 2. reuseExistingServer footgun guarded
Locally, if anything already holds port 4173, Playwright reuses it and the suite runs against the wrong app (observed: a stray `next-server` caused 84/86 failures). `e2e/global-setup.ts` now fetches the base URL once before any test and **fails fast** with an actionable message unless the served page is the a11y-calc demo (identified by its `<title>`). Also documented in `playwright.config.ts`.

## Verification (both directions)
- Real demo: `npm run test:e2e` → **86/86 passed**, preflight passes.
- Decoy server on 4173: preflight throws `E2E preflight: the server at http://localhost:4173 is not the a11y-calc demo …` and no tests run against it.
- `npm run lint` / `format:check` clean.

Closes #87