### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/a11y-calc",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/a11y-calc",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@afixt/a11y-assert": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/a11y-calc",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "type": "module",
   "description": "An accessible calculator React component with basic and scientific modes, styled after macOS Calculator.",
   "keywords": [


### PR DESCRIPTION
Version bump to **v0.2.0** (minor).

Since v0.1.5:
- feat(usecases): remaining scientific functions, error path, keyboard (#83)
- fix(api): export `CalculatorProps` from the package root — new public type (#93)
- test(e2e): run calculator.spec.ts in CI + reused-server guard (#87 → #95)
- ci: remove scheduled workflows; ZAP-only PR security job (#77/#90 → #84)
- ci(usecases): PR-time .uc.yaml validation gate (#92 → #97)
- docs(usecases): coverage/accuracy fixes (#88 → #96); ADR 0016 min-release-age policy (#86/#85 → #94)
- fix(deps)/fix(e2e): osv devDep patches, Tab-focus test (#81, #82)

Minor bump: contains a `feat` and a new public export; no breaking changes.