### PR TITLE
chore(npm): make published package visibility explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@afixt/a11y-calc",
   "version": "0.2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "description": "An accessible calculator React component with basic and scientific modes, styled after macOS Calculator.",
   "keywords": [


### PR DESCRIPTION
Part of a fleet-wide npm publish-configuration sweep. Mechanical change; no
behavior change to what actually gets published.

- Adds `publishConfig.access = "public"` to `package.json`, so publishing this
  package publicly is recorded in the manifest rather than depending on a CLI
  flag at publish time. A bare `npm publish` is now correct on its own.

`@afixt/a11y-calc` is already published publicly: `.github/workflows/release.yml`
runs `npm publish --provenance --access public`, and nothing in the repo sets
`restricted`. This change makes that intent explicit and keeps a manual or
local publish from accidentally defaulting to `restricted` (npm's default for
scoped packages).
