### PR TITLE
chore(release): v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/a11y-calc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/a11y-calc",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@afixt/a11y-assert": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/a11y-calc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publishConfig": {
     "access": "public"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,6 +46,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // userEvent-driven component tests routinely exceed vitest's 5s default
+    // on loaded machines; the assertions are fine, the budget was not.
+    testTimeout: 20000,
     setupFiles: './src/test-setup.ts',
     exclude: ['e2e/**', 'node_modules/**'],
     coverage: {


### PR DESCRIPTION
Version bump for the v0.2.1 patch release.

- `chore(release): v0.2.1` — bumps `package.json` / `package-lock.json`.
- `test: raise vitest testTimeout to 20s` — see below.

**Note:** this branch is squash-merged under the `chore(release): v0.2.1`
subject, so the test-config change is folded into a commit whose message only
mentions the bump. Calling it out here so it isn't invisible in `git log`.

### Why the timeout change rides along

`vite.config.ts` set no `testTimeout`, so the suite ran on vitest's 5s default.
The `userEvent`-heavy component tests intermittently blew that budget on loaded
machines, failing the pre-push `check:all` gate on a *different* test each run
(`handles decimal operands`, `clears aria-pressed after equals`, `still passes
after a few interactions in scientific mode`). Every failure was
`Test timed out in 5000ms` — no assertion ever failed, and the affected tests
pass in isolation. Measured worst case was ~11s of real test time for a single
test, so 20s gives roughly 2x headroom while still catching a genuinely hung
test.

This applies to CI as well, which was passing on speed rather than margin.

### Release contents

Only one functional commit since v0.2.0: #102, which makes published package
visibility explicit via `publishConfig.access`. Patch bump.
