### PR TITLE
Release v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/a11y-calc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/a11y-calc",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@afixt/a11y-assert": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/a11y-calc",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@afixt/a11y-calc",
   "version": "0.2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "type": "module",
   "description": "An accessible calculator React component with basic and scientific modes, styled after macOS Calculator.",
   "keywords": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,6 +46,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // userEvent-driven component tests routinely exceed vitest's 5s default
+    // on loaded machines; the assertions are fine, the budget was not.
+    testTimeout: 20000,
     setupFiles: './src/test-setup.ts',
     exclude: ['e2e/**', 'node_modules/**'],
     coverage: {


### PR DESCRIPTION
Patch release. No user-facing behavior change to the component itself.

### What's shipping

- **#102** — `chore(npm): make published package visibility explicit`. Adds
  `publishConfig.access: "public"` to `package.json` so a bare `npm publish`
  is correct on its own rather than depending on the `--access public` flag
  that `release.yml` passes. The package was already published publicly; this
  records that intent in the manifest and prevents a manual or local publish
  from defaulting to `restricted`.
- **#103** — version bump to v0.2.1, plus a test-infrastructure fix: the suite
  had no `testTimeout`, so it ran on vitest's 5s default and intermittently
  lost `userEvent`-heavy component tests to timeouts on loaded machines. Now
  set to 20s. No assertions changed; no product code changed.

### Breaking changes

None.

### API surface

Unchanged. No changes to `src/` — the diff since v0.2.0 touches only
`package.json`, `package-lock.json`, and `vite.config.ts`.

https://github.com/AFixt/a11y-calc/compare/v0.2.0...develop
