### PR TITLE
chore(release): v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-08-20
+
+### Added
+
+- `CHANGELOG.md` documenting the release history from v0.1.1 onward, in
+  Keep a Changelog format, shipped in the published package. (#107)
+
 ### Security
 
 - Override `puppeteer` to 25.6.0 to clear the unfixable `extract-zip` advisory
@@ -121,7 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `release.yml` for OIDC-based npm publish with provenance (#11).
 - Tooling baseline: ESLint, Husky gates, size-limit, and CI workflows.
 
-[Unreleased]: https://github.com/AFixt/a11y-calc/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/AFixt/a11y-calc/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/AFixt/a11y-calc/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/AFixt/a11y-calc/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/AFixt/a11y-calc/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/AFixt/a11y-calc/compare/v0.1.4...v0.1.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/a11y-calc",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/a11y-calc",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@afixt/a11y-assert": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/a11y-calc",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Version bump for the v0.2.2 patch release.

Bumps `package.json` / `package-lock.json`, and promotes the changelog's
`[Unreleased]` section to `## [0.2.2] - 2026-08-20` with a fresh empty
`[Unreleased]` above it and a new `v0.2.1...v0.2.2` compare link.

Also adds the `### Added` entry for #107 itself, which was missing — the
changelog could not document its own arrival before it existed.

### Release contents

- #106 — puppeteer override clearing the extract-zip advisory (`Security`)
- #107 — the changelog (`Added`)

No `feat` and no breaking change in the range, hence patch.